### PR TITLE
Log classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,5 @@ development_app
 .byebug_history
 node_modules/
 npm_debug.log
+*.gem
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ PATH
       decidim-accountability (>= 0.22)
       decidim-admin (>= 0.22)
       decidim-core (>= 0.22)
+      decidim-forms (>= 0.22)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Decidim::TimeTracker
 
-[![Build Status](https://github.com/Platoniq/decidim-module-time_tracker/workflows/Build/badge.svg)](https://github.com/Platoniq/decidim-module-time_tracker/actions)
+[![Test](https://github.com/Platoniq/decidim-module-time_tracker/workflows/Test/badge.svg)](https://github.com/Platoniq/decidim-module-time_tracker/actions)
 [![Maintainability](https://api.codeclimate.com/v1/badges/9372a7def91c50d04e8c/maintainability)](https://codeclimate.com/github/Platoniq/decidim-module-time_tracker/maintainability)
 [![codecov](https://codecov.io/gh/Platoniq/decidim-module-time_tracker/branch/master/graph/badge.svg)](https://codecov.io/gh/Platoniq/decidim-module-time_tracker)
 
@@ -57,8 +57,8 @@ Decidim::TimeTracker.configure do |config|
 end
 ```
 
-> **NOTE:** If you customize your questionnaire, you can use ani I18n key to translate it. Just add it to your locales.
-> You can also just put a text with no translation, then it will be used for all languages
+> **NOTE:** If you customize your questionnaire, you can use any I18n key to translate it. Just add it to your locales.
+> You also can just put a direct text with no translations, then it will be used for all languages.
 
 ## Contributing
 

--- a/app/cells/decidim/time_tracker/milestone_cell.rb
+++ b/app/cells/decidim/time_tracker/milestone_cell.rb
@@ -19,14 +19,12 @@ module Decidim
       end
 
       def title
-        if list?
-          link_to milestones_path do
-            content_tag :h4, class: "card__title" do
-              t("title", user_name: model.user.name, scope: "decidim.time_tracker.milestone") if options[:type] == :list
-            end
+        return content_tag :strong, model.title unless list?
+
+        link_to milestones_path do
+          content_tag :h4, class: "card__title" do
+            t("title", user_name: model.user.name, scope: "decidim.time_tracker.milestone")
           end
-        else
-          content_tag :strong, model.title
         end
       end
 
@@ -34,7 +32,7 @@ module Decidim
         image_url = model.attachments&.first&.url
 
         if image_url.present?
-          link_to image_url, target: :blank do
+          link_to milestones_path, class: "card__link" do
             image_tag image_url, class: "card__image"
           end
         else

--- a/app/models/decidim/time_tracker/activity.rb
+++ b/app/models/decidim/time_tracker/activity.rb
@@ -5,6 +5,9 @@ module Decidim
     # The data store for a Activity in the Decidim::TimeTracker component. It
     # stores a description and other useful information related to an activity.
     class Activity < ApplicationRecord
+      include Decidim::Traceable
+      include Decidim::Loggable
+
       self.table_name = :decidim_time_tracker_activities
 
       belongs_to :task,
@@ -116,6 +119,10 @@ module Decidim
         return :finished if end_date < Time.current.beginning_of_day
 
         :open
+      end
+
+      def self.log_presenter_class_for(_log)
+        Decidim::TimeTracker::AdminLog::ActivityPresenter
       end
 
       private

--- a/app/models/decidim/time_tracker/assignation.rb
+++ b/app/models/decidim/time_tracker/assignation.rb
@@ -4,6 +4,9 @@ module Decidim
   module TimeTracker
     # The data store for an assigne in the Decidim::TimeTracker component.
     class Assignation < ApplicationRecord
+      include Decidim::Traceable
+      include Decidim::Loggable
+
       self.table_name = :decidim_time_tracker_assignations
 
       belongs_to :activity,
@@ -52,6 +55,10 @@ module Decidim
         statuses.map { |status| send(status) }.sum
       end
       # rubocop:enable Lint/UselessAssignment
+
+      def self.log_presenter_class_for(_log)
+        Decidim::TimeTracker::AdminLog::AssignationPresenter
+      end
     end
   end
 end

--- a/app/models/decidim/time_tracker/milestone.rb
+++ b/app/models/decidim/time_tracker/milestone.rb
@@ -19,6 +19,8 @@ module Decidim
       has_one :task,
               through: :activity,
               class_name: "Decidim::TimeTracker::Task"
+
+      delegate :component, to: :task
     end
   end
 end

--- a/app/models/decidim/time_tracker/task.rb
+++ b/app/models/decidim/time_tracker/task.rb
@@ -4,6 +4,9 @@ module Decidim
   module TimeTracker
     # The data store for a Task in the Decidim::TimeTracker component.
     class Task < ApplicationRecord
+      include Decidim::Traceable
+      include Decidim::Loggable
+
       self.table_name = :decidim_time_tracker_tasks
 
       belongs_to :time_tracker,
@@ -30,6 +33,10 @@ module Decidim
 
       def user_is_assignation?(user, filter: :accepted)
         Assignation.where(user: user, activity: activities).send(filter).any?
+      end
+
+      def self.log_presenter_class_for(_log)
+        Decidim::TimeTracker::AdminLog::TaskPresenter
       end
     end
   end

--- a/app/models/decidim/time_tracker/task.rb
+++ b/app/models/decidim/time_tracker/task.rb
@@ -17,6 +17,7 @@ module Decidim
                dependent: :destroy
 
       delegate :questionnaire, to: :time_tracker
+      delegate :component, to: :time_tracker
 
       def starts_at
         activities.order(start_date: :asc).first&.start_date

--- a/app/models/decidim/time_tracker/time_tracker.rb
+++ b/app/models/decidim/time_tracker/time_tracker.rb
@@ -5,6 +5,8 @@ module Decidim
     class TimeTracker < ApplicationRecord
       include Decidim::HasComponent
       include Decidim::Forms::HasQuestionnaire
+      include Decidim::Traceable
+      include Decidim::Loggable
 
       self.table_name = :decidim_time_trackers
 

--- a/app/presenters/decidim/time_tracker/admin_log/activity_presenter.rb
+++ b/app/presenters/decidim/time_tracker/admin_log/activity_presenter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Decidim
+  module TimeTracker
+    module AdminLog
+      # This class holds the logic to present a `Decidim::TimeTracker::Activity`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    ActivityPresenter.new(action_log, view_helpers).present
+      class ActivityPresenter < Decidim::Log::BasePresenter
+        private
+
+        def diff_fields_mapping
+          {
+            description: :i18n,
+            active: :boolean
+          }
+        end
+
+        def i18n_labels_scope
+          "activemodel.attributes.time_tracker.activity"
+        end
+
+        def action_string
+          case action
+          when "create", "delete", "update"
+            "decidim.time_tracker.admin_log.activity.#{action}"
+          else
+            super
+          end
+        end
+
+        def has_diff?
+          action == "delete" || super
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/decidim/time_tracker/admin_log/assignation_presenter.rb
+++ b/app/presenters/decidim/time_tracker/admin_log/assignation_presenter.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Decidim
+  module TimeTracker
+    module AdminLog
+      # This class holds the logic to present a `Decidim::TimeTracker::Assignation`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    AssignationPresenter.new(action_log, view_helpers).present
+      class AssignationPresenter < Decidim::Log::BasePresenter
+        private
+
+        def diff_fields_mapping
+          {
+            status: :string,
+            decidim_user_id: :user,
+            activity_id: "Decidim::TimeTracker::AdminLog::ValueTypes::ActivityPresenter",
+            invited_at: :date,
+            invited_by_user: :user,
+            requested_at: :date,
+            tos_accepted_at: :date
+          }
+        end
+
+        def i18n_labels_scope
+          "activemodel.attributes.time_tracker.assignation"
+        end
+
+        def action_string
+          case action
+          when "create", "delete", "update"
+            "decidim.time_tracker.admin_log.assignation.#{action}"
+          else
+            super
+          end
+        end
+
+        def has_diff?
+          action == "delete" || super
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/decidim/time_tracker/admin_log/task_presenter.rb
+++ b/app/presenters/decidim/time_tracker/admin_log/task_presenter.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Decidim
+  module TimeTracker
+    module AdminLog
+      # This class holds the logic to present a `Decidim::TimeTracker::Task`
+      # for the `AdminLog` log.
+      #
+      # Usage should be automatic and you shouldn't need to call this class
+      # directly, but here's an example:
+      #
+      #    action_log = Decidim::ActionLog.last
+      #    view_helpers # => this comes from the views
+      #    TaskPresenter.new(action_log, view_helpers).present
+      class TaskPresenter < Decidim::Log::BasePresenter
+        private
+
+        def diff_fields_mapping
+          {
+            name: :i18n,
+            time_tracker_id: "Decidim::TimeTracker::AdminLog::ValueTypes::TimeTrackerPresenter",
+            active: :boolean,
+            updated_at: :date
+          }
+        end
+
+        def i18n_labels_scope
+          "activemodel.attributes.time_tracker.task"
+        end
+
+        def action_string
+          case action
+          when "create", "delete", "update"
+            "decidim.time_tracker.admin_log.task.#{action}"
+          else
+            super
+          end
+        end
+
+        def has_diff?
+          action == "delete" || super
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/decidim/time_tracker/admin_log/value_types/activity_presenter.rb
+++ b/app/presenters/decidim/time_tracker/admin_log/value_types/activity_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module TimeTracker
+    module AdminLog
+      module ValueTypes
+        class ActivityPresenter < Decidim::Log::ValueTypes::DefaultPresenter
+          # Public: Presents the value as a Decidim::TimeTracker. If the activity can
+          # be found, it shows its title. Otherwise it shows its ID.
+          #
+          # Returns an HTML-safe String.
+          def present
+            return unless value
+            return h.translated_attribute(activity&.description) if activity
+
+            I18n.t("not_found", id: value, scope: "decidim.log.value_types.activity_presenter")
+          end
+
+          private
+
+          def activity
+            @activity ||= Decidim::TimeTracker::Activity.find_by(id: value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/presenters/decidim/time_tracker/admin_log/value_types/time_tracker_presenter.rb
+++ b/app/presenters/decidim/time_tracker/admin_log/value_types/time_tracker_presenter.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Decidim
+  module TimeTracker
+    module AdminLog
+      module ValueTypes
+        class TimeTrackerPresenter < Decidim::Log::ValueTypes::DefaultPresenter
+          # Public: Presents the value as a Decidim::TimeTracker. If the time_tracker can
+          # be found, it shows its title. Otherwise it shows its ID.
+          #
+          # Returns an HTML-safe String.
+          def present
+            return unless value
+            return h.translated_attribute(time_tracker&.component&.name) if time_tracker
+
+            I18n.t("not_found", id: value, scope: "decidim.log.value_types.time_tracker_presenter")
+          end
+
+          private
+
+          def time_tracker
+            @time_tracker ||= Decidim::TimeTracker::TimeTracker.find_by(id: value)
+          end
+        end
+      end
+    end
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,13 @@ en:
             account_message: <a href="%{sign_in_url}">Sign in with your account</a>
               or <a href="%{sign_up_url}">sign up</a> to participate in this activity.
             request: Request to join activity
+    log:
+      value_types:
+        activity_presenter:
+          not_found: 'The Activity was not found on the database (ID: %{id})'
+        time_tracker_presenter:
+          not_found: 'The Time Tracker component was not found on the database (ID:
+            %{id})'
     time_tracker:
       admin:
         actions:
@@ -144,6 +151,19 @@ en:
           create:
             error: Error importing the Time Tracker data to accountability
             success: Time Tracker data exported to accountability successfully
+      admin_log:
+        activity:
+          create: "%{user_name} created the %{resource_name} activity"
+          delete: "%{user_name} removed the %{resource_name} activity"
+          update: "%{user_name} updated the %{resource_name} activity"
+        assignation:
+          create: "%{user_name} created an assignation"
+          delete: "%{user_name} removed an assignation"
+          update: "%{user_name} updated an assignation"
+        task:
+          create: "%{user_name} created the %{resource_name} task"
+          delete: "%{user_name} removed the %{resource_name} task"
+          update: "%{user_name} updated the %{resource_name} task"
       assignations:
         request:
           error: Activity assignation request failed!

--- a/decidim-time_tracker.gemspec
+++ b/decidim-time_tracker.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "decidim-accountability", ">= #{Decidim::TimeTracker::DECIDIM_VERSION}"
   s.add_dependency "decidim-admin", ">= #{Decidim::TimeTracker::DECIDIM_VERSION}"
   s.add_dependency "decidim-core", ">= #{Decidim::TimeTracker::DECIDIM_VERSION}"
+  s.add_dependency "decidim-forms", ">= #{Decidim::TimeTracker::DECIDIM_VERSION}"
 
   s.add_development_dependency "decidim-dev", ">= #{Decidim::TimeTracker::DECIDIM_VERSION}"
 end

--- a/lib/decidim/time_tracker/test/admin_log_presenter_examples.rb
+++ b/lib/decidim/time_tracker/test/admin_log_presenter_examples.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+shared_examples "present admin log entry" do
+  subject(:presenter) { described_class.new(action_log, helper) }
+
+  let(:organization) { create(:organization) }
+  let(:user) { create(:user, organization: organization) }
+  let(:action) { "create" }
+  let(:action_log) do
+    create(
+      :action_log,
+      user: user,
+      action: action,
+      resource: admin_log_resource
+    )
+  end
+
+  before do
+    helper.extend(Decidim::ApplicationHelper)
+    helper.extend(Decidim::TranslationsHelper)
+  end
+
+  describe "#present" do
+    subject { presenter.present }
+
+    context "when the logged action is one that shows diff and the action log does not have an associated version" do
+      it "returns an empty diff" do
+        expect(subject).not_to include("class=\"logs__log__diff\"")
+      end
+    end
+  end
+end

--- a/spec/cells/milestone_cell_spec.rb
+++ b/spec/cells/milestone_cell_spec.rb
@@ -6,55 +6,55 @@ module Decidim::TimeTracker
   describe MilestoneCell, type: :cell do
     controller Decidim::TimeTracker::MilestonesController
 
-    subject { cell("decidim/time_tracker/milestone", model, options).call }
+    subject { my_cell.call }
 
+    let(:my_cell) { cell("decidim/time_tracker/milestone", model, type: type) }
     let(:model) { create(:milestone) }
-    let(:options) { {} }
+    let(:type) { nil }
+    # For some reason "within" does not work well in cells, so using "find"
+    let(:card_header) { subject.find(".card__header") }
+    let(:card_footer) { subject.find(".card__footer") }
+    let(:card_link) { subject.find(".card__link") }
 
     it "renders the cell" do
       expect(subject).to have_css(".card--milestone")
     end
 
+    it "has common classes" do
+      expect(subject).to have_css(".card__header")
+      expect(subject).to have_css(".card__footer")
+    end
+
     context "when the cell is called with no options" do
       it "shows the milestone title as card title" do
-        within ".card__header" do
-          expect(subject).to have_text(model.title)
-        end
+        expect(card_header).to have_text(model.title)
       end
 
       it "doesn't link to the user milestones" do
-        within ".card__header" do
-          expect(subject).not_to have_link(milestones_path(user_id: user.id))
-        end
+        expect(card_header).not_to have_link(my_cell.milestones_path)
       end
 
       it "shows the milestone created_at date in the footer" do
-        within ".card__footer" do
-          expect(subject).to have_text(model.created_at.strftime("%H:%M"))
-          expect(subject).to have_text(model.created_at.strftime("%d %b %Y"))
-        end
+        expect(card_footer).to have_text(model.created_at.strftime("%H:%M"))
+        expect(card_footer).to have_text(model.created_at.strftime("%d %b %Y"))
       end
     end
 
     context "when the cell is called with `type: :list` in options" do
-      let(:options) { { type: :list } }
+      let(:type) { :list }
 
       it "shows the user title as card title" do
-        within ".card__header" do
-          expect(subject).to have_text(user.name)
-        end
+        expect(card_header).to have_css("h4")
+        expect(card_header).to have_text(model.user.name)
+        expect(card_header).to have_text("activity")
       end
 
       it "links to the user milestones" do
-        within ".card__header" do
-          expect(subject).to have_link(milestones_path(user_id: user.id))
-        end
+        expect(card_header).to have_link(href: my_cell.milestones_path)
       end
 
       it "shows the elapsed time for the user in the footer" do
-        within ".card__footer" do
-          expect(subject).to have_text(model.activity.user_seconds_elapsed(model.user))
-        end
+        expect(card_footer).to have_text(model.activity.user_seconds_elapsed(model.user))
       end
     end
 
@@ -69,6 +69,12 @@ module Decidim::TimeTracker
 
       it "uses that image" do
         expect(subject.to_s).to include(model.attachments.first.url)
+      end
+
+      it "links to the user milestones" do
+        expect(subject).to have_css(".card__link")
+        expect(card_link).to have_css(".card__image")
+        expect(card_link[:href]).to eq(my_cell.milestones_path)
       end
     end
   end

--- a/spec/presenters/admin_log/activity_presenter_spec.rb
+++ b/spec/presenters/admin_log/activity_presenter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/time_tracker/test/admin_log_presenter_examples"
+
+module Decidim::TimeTracker
+  describe AdminLog::ActivityPresenter, type: :helper do
+    include_examples "present admin log entry" do
+      let(:participatory_space) { create(:participatory_process, organization: organization) }
+      let(:component) { create(:time_tracker_component, participatory_space: participatory_space) }
+      let(:time_tracker) { create(:time_tracker, component: component) }
+      let(:task) { create(:task, time_tracker: time_tracker) }
+      let(:admin_log_resource) { create(:activity, task: task) }
+      let(:action) { "update" }
+    end
+  end
+end

--- a/spec/presenters/admin_log/assignation_presenter_spec.rb
+++ b/spec/presenters/admin_log/assignation_presenter_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/time_tracker/test/admin_log_presenter_examples"
+
+module Decidim::TimeTracker
+  describe AdminLog::AssignationPresenter, type: :helper do
+    include_examples "present admin log entry" do
+      let(:participatory_space) { create(:participatory_process, organization: organization) }
+      let(:component) { create(:time_tracker_component, participatory_space: participatory_space) }
+      let(:time_tracker) { create(:time_tracker, component: component) }
+      let(:task) { create(:task, time_tracker: time_tracker) }
+      let(:admin_log_resource) { create(:assignation, task: task) }
+      let(:action) { "update" }
+    end
+  end
+end

--- a/spec/presenters/admin_log/task_presenter_spec.rb
+++ b/spec/presenters/admin_log/task_presenter_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "decidim/time_tracker/test/admin_log_presenter_examples"
+
+module Decidim::TimeTracker
+  describe AdminLog::TaskPresenter, type: :helper do
+    include_examples "present admin log entry" do
+      let(:participatory_space) { create(:participatory_process, organization: organization) }
+      let(:component) { create(:time_tracker_component, participatory_space: participatory_space) }
+      let(:time_tracker) { create(:time_tracker, component: component) }
+      let(:admin_log_resource) { create(:task, time_tracker: time_tracker) }
+      let(:action) { "update" }
+    end
+  end
+end

--- a/spec/presenters/admin_log/value_types/activity_presenter_spec.rb
+++ b/spec/presenters/admin_log/value_types/activity_presenter_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::TimeTracker
+  describe AdminLog::ValueTypes::ActivityPresenter do
+    include Decidim::TranslatableAttributes
+
+    subject { described_class.new(activity_id, self) }
+
+    let(:activity) { create :activity, description: description }
+    let(:activity_id) { activity.id }
+    let(:description) do
+      {
+        "en" => "My value",
+        "es" => "My title in Spanish"
+      }
+    end
+
+    describe "#present" do
+      it "handles i18n fields" do
+        expect(subject.present).to eq "My value"
+      end
+
+      context "when no value found" do
+        let(:activity_id) { 1234 }
+
+        it "returns not found" do
+          expect(subject.present).to include "not found"
+          expect(subject.present).to include "ID: #{activity_id}"
+        end
+      end
+    end
+  end
+end

--- a/spec/presenters/admin_log/value_types/time_tracker_presenter_spec.rb
+++ b/spec/presenters/admin_log/value_types/time_tracker_presenter_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+module Decidim::TimeTracker
+  describe AdminLog::ValueTypes::TimeTrackerPresenter do
+    include Decidim::TranslatableAttributes
+
+    subject { described_class.new(time_tracker_id, self) }
+
+    let(:time_tracker) { create :time_tracker }
+    let(:time_tracker_id) { time_tracker.id }
+
+    describe "#present" do
+      it "handles i18n fields" do
+        expect(subject.present).to eq time_tracker.component.name["en"]
+      end
+
+      context "when no value found" do
+        let(:time_tracker_id) { 1234 }
+
+        it "returns not found" do
+          expect(subject.present).to include "not found"
+          expect(subject.present).to include "ID: #{time_tracker_id}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Enables paper_trail in models handle by admins. Also some basic presenters for the activity log

fixes #20

also refactors cell specs as some capybara handler dont' work well there (the `within` statement fails silently making the test pass without actually testing anything). With this change milestone_cell should increase coverate to 100%.

Example: this is not covered:
![image](https://user-images.githubusercontent.com/1401520/101893142-9e36d100-3ba4-11eb-8c75-017c5017605d.png)

But, supposedly, this should cover it:
![image](https://user-images.githubusercontent.com/1401520/101893216-bf97bd00-3ba4-11eb-82df-c9746891e2aa.png)


![image](https://user-images.githubusercontent.com/1401520/101880862-deda1e80-3b93-11eb-82ca-76340143f693.png)
